### PR TITLE
Fix: Dynamic icon for Appearance button in My Account dropdown

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -406,7 +406,12 @@ export default function Header() {
                       <DropdownMenuSeparator />
                       <DropdownMenuSub>
                         <DropdownMenuSubTrigger>
-                          <UserPlus />
+                          {/* Dynamically changing the icon based on the theme */}
+                          {currentTheme === "light" && <MoonIcon size={16} />}
+                          {currentTheme === "dark" && (
+                            <SunMediumIcon size={16} />
+                          )}
+                          {currentTheme === "system" && <Monitor size={16} />}
                           <span>Appearance</span>
                         </DropdownMenuSubTrigger>
                         <DropdownMenuPortal>
@@ -420,7 +425,7 @@ export default function Header() {
                                 className="flex items-center gap-2"
                               >
                                 <Monitor size={16} />
-                                <span>Systen</span>
+                                <span>System</span>
                               </DropdownMenuRadioItem>
                               <DropdownMenuRadioItem
                                 value="light"


### PR DESCRIPTION
## 📄 Description  
This PR fixes the icon logic for the **Appearance** theme toggle in the **My Account** dropdown.  
The fix ensures that the icon dynamically reflects the currently selected theme mode:
- **Moon icon** for **Dark Mode** (indicates switch to Light Mode)
- **Sun icon** for **Light Mode** (indicates switch to Dark Mode)
- **Monitor icon** for **System Theme** (indicates system preference)

## 🔗 Related Issue(s)  
Closes #4

## 🛠️ Changes Made  
- Replaced static `UserPlus` icon with conditional logic.
- Displayed:
  - 🌙 Moon icon when **Dark Mode** is active (indicates switch to Light Mode)
  - ☀️ Sun icon when **Light Mode** is active (indicates switch to Dark Mode)
  - 🖥️ Monitor icon when **System Theme** is active (indicates system preference)
- Enhanced visual feedback and theme clarity for users.

## 🧪 Testing Details  
- [x] Ran `npm run dev` without errors  
- [x] Manual tests completed: Verified all 3 modes (Light, Dark, System) reflect the correct icon  
- [ ] New/updated unit tests (not applicable)

## 🎥 Demo Video 

https://github.com/user-attachments/assets/a62a9c43-6809-4653-a5a9-4685df1bae29

## 📝 Notes for Reviewers  
- This improves UI clarity and aligns with common UX patterns (like GitHub, VS Code).
- Feel free to suggest enhancements to the icon logic if needed.

---

# ✅ PR Checklist

- [x] My code follows the project’s style guidelines.  
- [x] I have performed a self-review of my code.  
- [x] I have commented my code where necessary.  
- [x] I have updated documentation where necessary.  
- [x] This PR is ready for a detailed review.